### PR TITLE
Resolve includes error (wasn't picking up included token type)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -487,7 +487,7 @@ impl Parser {
                 .canonicalize()
                 .unwrap_or_else(|_| {
                     panic!(
-                        "Uanble to canonicalize include path: {:?}",
+                        "Unable to canonicalize include path: {:?}",
                         self.origin_directory.join(target.clone())
                     )
                 });
@@ -507,12 +507,15 @@ impl Parser {
             for token in
                 Scanner::new_with_stack(&open_file(resolved_target), self.file_stack.clone())
             {
-                self.token_into(token, asg)
+                let token_type = token.token_type();
+                self.token_into(token, asg);
+                self.last_token_type = token_type;
             }
         } else {
             for token in
                 Scanner::new_with_stack(&open_file(resolved_target), self.file_stack.clone())
             {
+                self.last_token_type = TokenType::Text;
                 self.parse_text(token)
             }
         }

--- a/tests/block_tests.rs
+++ b/tests/block_tests.rs
@@ -244,6 +244,14 @@ fn test_include() {
 }
 
 #[test]
+fn test_include_respects_internal_breaks() {
+    let fn_pattern = "blocks/include-respects-internal-breaks";
+    let adoc_fn = format!("{}.adoc", fn_pattern);
+    let asg_json_fn = format!("{}.json", fn_pattern);
+    assert_parsed_doc_matches_expected_asg(&adoc_fn, &asg_json_fn)
+}
+
+#[test]
 fn test_table_simple() {
     let fn_pattern = "blocks/table-simple";
     let adoc_fn = format!("{}.adoc", fn_pattern);

--- a/tests/data/blocks/include-respects-internal-breaks.adoc
+++ b/tests/data/blocks/include-respects-internal-breaks.adoc
@@ -1,0 +1,1 @@
+include::para-internal-line-break.adoc[]

--- a/tests/data/blocks/include-respects-internal-breaks.json
+++ b/tests/data/blocks/include-respects-internal-breaks.json
@@ -1,0 +1,62 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "This is just a test to see if things get combined. For example, this should all\nbe one inline.",
+          "location": [
+            {
+              "line": 1,
+              "col": 1,
+              "file": [
+                "para-internal-line-break.adoc"
+              ]
+            },
+            {
+              "line": 2,
+              "col": 14,
+              "file": [
+                "para-internal-line-break.adoc"
+              ]
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1,
+          "file": [
+            "para-internal-line-break.adoc"
+          ]
+        },
+        {
+          "line": 2,
+          "col": 14,
+          "file": [
+            "para-internal-line-break.adoc"
+          ]
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 2,
+      "col": 14,
+      "file": [
+        "para-internal-line-break.adoc"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The issue was that the `last_token_type` was never being set based on the tokens coming from the includes.