### PR TITLE
Using result type to reflect scanning error

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -11,6 +11,8 @@ use self::tokens::TokenError;
 pub enum ScannerError {
     #[error(transparent)]
     Token(#[from] TokenError),
+    #[error("General error: `{0}`")]
+    String(String),
 }
 
 #[derive(Debug)]
@@ -460,8 +462,7 @@ impl<'a> Scanner<'a> {
             4 => self.add_token(TokenType::Heading4, false, 0),
             5 => self.add_token(TokenType::Heading5, false, 0),
             _ => {
-                error!("Invalid headling level: line {}", self.line);
-                std::process::exit(1)
+                return Err(ScannerError::String(format!("Invalid headling level: line {}", self.line)))
             }
         }
     }


### PR DESCRIPTION
This system already has a `ScannerError` that looks like it was built to be extended - I just added a `ScannerError::String` data constructor, and passed the call to `error!(...)` into `ScannerError::String(format!(...))` to allow end-users the ability to decide how they want to handle the error. I also removed the process kill line.